### PR TITLE
Update dpmmwrapper.py

### DIFF
--- a/dpmmpython/dpmmwrapper.py
+++ b/dpmmpython/dpmmwrapper.py
@@ -1,5 +1,5 @@
 import julia
-julia.Julia(compiled_modules=False)
+julia.install()
 from dpmmpython.priors import niw, multinomial
 from julia import DPMMSubClusters
 import numpy as np


### PR DESCRIPTION
addresses warning:
```</path/to/python>/lib/python3.9/site-packages/julia/core.py:687: FutureWarning: Accessing `Julia().<name>` to obtain Julia objects is deprecated.  Use `from julia import Main; Main.<name>` or `jl = Julia(); jl.eval('<name>')`.
  warnings.warn(
```